### PR TITLE
Change phraseapp to phrase

### DIFF
--- a/_posts/2017/2017-12-21-how-to-create-awesome-ui-texts.md
+++ b/_posts/2017/2017-12-21-how-to-create-awesome-ui-texts.md
@@ -27,15 +27,15 @@ In our case, we often have one-word-strings.
 One word.
 Sometimes you don't even know if this word is a subject or a verb.
 How can you be able to translate this into another language?
-This is one of the reasons, we decided to work with the software localization tool [PhraseApp](https://phraseapp.com/){:target="_blank"}.
-With the help of PhraseApp's [In-Context Editor](http://demo.phraseapp.com/){:target="_blank"} we are now able to see, and translate the single strings directly in our software.
+This is one of the reasons, we decided to work with the software localization tool [Phrase](https://phrase.com/){:target="_blank"}.
+With the help of Phrase's [In-Context Editor](https://phrase.com/demo/){:target="_blank"} we are now able to see, and translate the single strings directly in our software.
 
 ## Benefit of a good memory
 
 Having a look at the context is not enough.
 You also have to remember, which terminology, and phrasing you used in similar texts before.
 This way, you can come up with consistent, and understandable UI texts.
-[PhraseApp](https://phraseapp.com/){:target="_blank"} also offers a Translation Memory to tackle this.
+[Phrase](https://phrase.com/){:target="_blank"} also offers a Translation Memory to tackle this.
 But Translation Memories do not always show every result, and (most of the time) do not take into account syntax similarities, or content overlaps.
 Thus, it helps if you are able to remember what you already did before.
 So, stay concentrated, don't forget the past, and benefit from the work you already did.

--- a/_posts/2018/2018-07-19-rocking-the-stage-with-a-software-localization-tool.md
+++ b/_posts/2018/2018-07-19-rocking-the-stage-with-a-software-localization-tool.md
@@ -53,7 +53,7 @@ Besides this feature list, we also had an eye on the overall feature set, the pr
 What can I say?
 It wasn't an easy decision.
 We could have worked with nearly all of them.
-But some test accounts and discussions later, we decided to go with [PhraseApp](https://phraseapp.com/){:target="_blank"}.
+But some test accounts and discussions later, we decided to go with [Phrase](https://phrase.com/){:target="_blank"}.
 
 ## Organizational stuff
 
@@ -82,7 +82,7 @@ So we had a deeper look at our interal processes.
 Long story short, these are the most important Q&As we tackled:
 
 **Q**: Do we provide our developers with final UI texts before or after they develop a feature?   
-**A**: First, the developers have to create the keys while they are coding, but without any final texts. Afterwards, these keys will be automatically uploaded to PhraseApp (keyword: Git Synchronization). The final UI texts will only be delivered by our UI writers at this point in time. Thus, we can make use of all the features PhraseApp offers.
+**A**: First, the developers have to create the keys while they are coding, but without any final texts. Afterwards, these keys will be automatically uploaded to Phrase (keyword: Git Synchronization). The final UI texts will only be delivered by our UI writers at this point in time. Thus, we can make use of all the features Phrase offers.
 
 **Q**: How often do we create UI texts?   
 **A**: Twice a week.
@@ -97,7 +97,7 @@ With this (and some further minor changes), we reduced the localization and tran
 We thought that our translation agency would jump for joy when we tell them about the new localiztion tool.
 Finally, we would be able to provide really great context for all our translation keys with the In-Context Editor.
 We wouldn't need to handle our communication via email and XML files anymore.
-The agency could simply get their own PhraseApp account and start off translating.
+The agency could simply get their own Phrase account and start off translating.
 
 But we forgot that translators are used to their typical translation tools, and not yet to dedicated software localization tools.
 They would need to spend some time to get used to this new tool.

--- a/_posts/2018/2018-12-18-how-to-cope-with-a-localization-tool-in-action.md
+++ b/_posts/2018/2018-12-18-how-to-cope-with-a-localization-tool-in-action.md
@@ -10,13 +10,13 @@ authors: ["Christina"]
 about_authors: ["cgebken"]
 ---
 
-In this series of blog posts, you've accompanied us on our journey towards an improved localization process with the help of the localization tool [PhraseApp](https://phraseapp.com/){:target="_blank"}.
-We've already talked about our [former localization flow](/blog/language-and-localization/why-the-heck-would-we-need-a-software-localization-tool/), and our learnings and improvements when [integrating PhraseApp](/blog/language-and-localization/rocking-the-stage-with-a-software-localization-tool/).
+In this series of blog posts, you've accompanied us on our journey towards an improved localization process with the help of the localization tool [Phrase](https://phrase.com/){:target="_blank"}.
+We've already talked about our [former localization flow](/blog/language-and-localization/why-the-heck-would-we-need-a-software-localization-tool/), and our learnings and improvements when [integrating Phrase](/blog/language-and-localization/rocking-the-stage-with-a-software-localization-tool/).
 But now it's time to talk about challenges that we faced during this restructuring time, and in some regards are still facing.
 
 ## There's still no way around screenshots
 
-PhraseApp offers great features such as Git-Synchronization, or In-Context Editor.
+Phrase offers great features such as Git-Synchronization, or In-Context Editor.
 If you'd like to get more detailed information on these, check back on our post ["Rocking the stage with a software localization tool"](/blog/language-and-localization/rocking-the-stage-with-a-software-localization-tool/).
 Nevertheless, some of these features are not the one and only solution for us.
 This is especially true for the In-Context Editor.
@@ -36,7 +36,7 @@ They will know what to do, and it will make your life easier!)
 After setting up the Git Synchronization, we figured out that our current Git workflow no longer matched our requirements, and that we needed to make some changes.
 Our solution was to introduce a branch called `l10n`.
 This branch is exclusively used for PRs with code changes that somehow affect localization, e.g. PRs with newly added keys.
-In order to enable our UI writers to edit these keys, PhraseApp is also connected to the `l10n` branch.
+In order to enable our UI writers to edit these keys, Phrase is also connected to the `l10n` branch.
 All other code changes will use our `master` branch, which is regularly rolled out to our live platforms serving our merchants and their customers.
 This way, no untranslated keys will be visible in our UI, and code changes that are not related to localization are not blocked.
 
@@ -87,14 +87,14 @@ Here's a little explanation for the column titles:
 - **Approved**: Receives a checkmark once the Localization Manager has approved the PR.
 - **Merged**: Receives a checkmark once the PR was merged into the `l10n` branch by the development team.
 - **Translation date**: Contains the date the keys will be processed by the UI writers.
-- **Merged back**: Receives a checkmark once the PR of PhraseApp with new translations was merged back into the `l10n` branch by the development team.
-- **Comment**: Contains comments if needed, e.g. a reminder that keys in PhraseApp need to be deleted once the PR is merged.
+- **Merged back**: Receives a checkmark once the PR of Phrase with new translations was merged back into the `l10n` branch by the development team.
+- **Comment**: Contains comments if needed, e.g. a reminder that keys in Phrase need to be deleted once the PR is merged.
 
 With the help of this list, it's much easier to keep an overview of localization-related PRs and their approvals.
 
 ## The effort was worth it!
 
-It's now almost one year ago that we introduced PhraseApp.
+It's now almost one year ago that we introduced Phrase.
 That's why we lately had a localization retrospective with our UI writers, developers, the responsible Product Owner, and our Localization Manager.
 And...we are happy!
 Even though, there are still some challenges that pop up every now and then.

--- a/_posts/2019/2019-03-26-behind-the-scenes-localization-at-epages.md
+++ b/_posts/2019/2019-03-26-behind-the-scenes-localization-at-epages.md
@@ -37,13 +37,13 @@ Now that I was so familiar with the topic of software localization, and introduc
 It's not so much different from localizing any other software, I guess.
 But we work agile.
 We have many small features at short intervals, and therefore smaller translation packages.
-For this reason (and several others), we decided to use PhraseApp as our localization tool.
+For this reason (and several others), we decided to use [Phrase](https://phrase.com/){:target="_blank"} as our localization tool.
 
-### Why PhraseApp?
+### Why Phrase?
 
 It facilitated the communication with the developers A LOT.
 They can concentrate on development, while I can still arrange the coordination and translation of new features in a timely manner.
-What's more, PhraseApp comes with a Translation Memory and an In-Context Editor. 
+What's more, Phrase comes with a Translation Memory and an In-Context Editor. 
 Especially the topic of providing context to our translators was a big issue before we introduced the tool.
 
 ### How much programming must a Localization Manager know to work on software localization?
@@ -68,7 +68,7 @@ And sure, there were some setbacks.
 But we have coped.
 
 There were also things coming my way I did not think of from the beginning.
-For example, it was not that easy to find translation agencies that committed to work with PhraseApp, and also to work agile.
+For example, it was not that easy to find translation agencies that committed to work with Phrase, and also to work agile.
 We had to make some compromises.
 But we found a way, and we are constantly striving to improve the process.
 
@@ -89,7 +89,7 @@ This helps me to understand the software and our developers' work even better, w
 
 ### What are your goals for 2019?
 
-I'd like to find more use cases for using PhraseApp within the company, as well as to equip our new product with a new language.
+I'd like to find more use cases for using Phrase within the company, as well as to equip our new product with a new language.
 And of course, I will never stop improving our current translation process.
 
 ### Sounds great! All the best, and thanks again for your time.

--- a/_posts/2019/2019-06-13-how-to-level-up-your-global-business-with-software-localization.md
+++ b/_posts/2019/2019-06-13-how-to-level-up-your-global-business-with-software-localization.md
@@ -11,20 +11,20 @@ authors: ["Christin"]
 about_authors: ["crichter"]
 ---
 
-Do you have your strings ready and want to move into the [localization](https://phraseapp.com/blog/posts/l10n-all-stats-facts-data-youll-ever-need/?utm_campaign=l10n-simple-definition&utm_medium=blog-relations&utm_source=epages-blog){:target="_blank"} (l10n) process, but you are not sure where and how to start?
+Do you have your strings ready and want to move into the [localization](https://phrase.com/blog/posts/l10n-all-stats-facts-data-youll-ever-need/?utm_campaign=l10n-simple-definition&utm_medium=blog-relations&utm_source=epages-blog){:target="_blank"} (l10n) process, but you are not sure where and how to start?
 This is a short introduction to best practices that will ensure the flawless integration of your software localization process with your design, programming and iteration environment.
 No matter if you have different types of content or technical requirements, at the end of your localization process, it should be content that is ready for market release in your chosen locale.
 Learn more about the possibilities and tools you should rely on in the following sections.
 
 ## How to prepare for software localization
 
-As a first step, before you can even think about starting the software localization, you need to ensure that your content is ready for [internationalization](https://phraseapp.com/blog/posts/i18n-a-simple-definition/?utm_campaign=i18n-simple-definition&utm_medium=blog-relations&utm_source=epages-blog){:target="_blank"} (i18n).
+As a first step, before you can even think about starting the software localization, you need to ensure that your content is ready for [internationalization](https://phrase.com/blog/posts/i18n-a-simple-definition/?utm_campaign=i18n-simple-definition&utm_medium=blog-relations&utm_source=epages-blog){:target="_blank"} (i18n).
 This means your design should take into account different length of strings, the readiness for left-to-right and right-to-left reading, the use of UTF and other various factors.
 Furthermore, you need to ensure that you opt for a full locale and not just a language to adjust date formats, spelling and word choices respectively.
 
 The process of internationalization describes the generalization of your design so as to be ready for the different locales.
 This is one of the most important steps to get ready for your software localization process and cannot be skipped if you wish to avoid neverending bug fixes further down the line.
-If this is your first localization effort, it makes sense to get a localization or [globalization](https://phraseapp.com/blog/posts/globalization-vs-localization/?utm_campaign=globalization-vs-localization&utm_medium=blog-relations&utm_source=epages-blog){:target="_blank"} expert on board who can help you with the details.
+If this is your first localization effort, it makes sense to get a localization or [globalization](https://phrase.com/blog/posts/globalization-vs-localization/?utm_campaign=globalization-vs-localization&utm_medium=blog-relations&utm_source=epages-blog){:target="_blank"} expert on board who can help you with the details.
 
 Once your internationalization process has been finished, you can proceed to the extraction of the strings that need to be localized.
 This extraction can happen, for instance, through SaaS as an automated procedure, which saves developers a lot of time and headache previously encountered when preparing sheets and files.
@@ -33,8 +33,8 @@ The automated extraction also allows for fewer errors and ensures that no extras
 ## How to decide on how to localize your software
 
 Now that your content is ready, you can start localizing your software.
-In order to do that, you need to decide whether to keep the localization in your hands and work with a team of translators using a [software localization tool](https://phraseapp.com/blog/posts/questions-to-ask-when-evaluating-the-best-software-localization-tool/?utm_campaign=5-questions-l10n-tool&utm_medium=blog-relations&utm_source=epages-blog){:target="_blank"}, or whether to hand the process over to a Language Service Provider (LSP) specialized on software localization.
-In any of those two cases, you need to ensure that only the best [localization management](https://phraseapp.com/on/localization-management?utm_campaign=localization-management&utm_medium=blog-relations&utm_source=epages-blog){:target="_blank"} and quality assessment practices are in place.
+In order to do that, you need to decide whether to keep the localization in your hands and work with a team of translators using a [software localization tool](https://phrase.com/blog/posts/questions-to-ask-when-evaluating-the-best-software-localization-tool/?utm_campaign=5-questions-l10n-tool&utm_medium=blog-relations&utm_source=epages-blog){:target="_blank"}, or whether to hand the process over to a Language Service Provider (LSP) specialized on software localization.
+In any of those two cases, you need to ensure that only the best [localization management](https://phrase.com/on/localization-management?utm_campaign=localization-management&utm_medium=blog-relations&utm_source=epages-blog){:target="_blank"} and quality assessment practices are in place.
 
 Currently, there is an increased opportunity to capitalize on new tools which focus on the localization of content.
 They are built to streamline your workflow, can be easily implemented and also facilitate the simultaneous workflow of everyone involved in your localization process.
@@ -74,4 +74,4 @@ All comments and requests for alterations will then have to be taken into accoun
 This step will help you guarantee the best possible outcome and facilitate any following iterations from your side.
 Localization today often happens simultaneously with iterations and updates.
 Therefore, it is of utmost importance to have an elaborate workflow in place and rely on a strong software localization tool.
-If you are still looking for one, give [PhraseApp](https://phraseapp.com/?utm_campaign=phraseapp-homepage&utm_medium=blog-relations&utm_source=epages-blog){:target="_blank"} a try.
+If you are still looking for one, give [Phrase](https://phrase.com/?utm_campaign=phraseapp-homepage&utm_medium=blog-relations&utm_source=epages-blog){:target="_blank"} a try.


### PR DESCRIPTION
Reason for this change is the name change from PhraseApp to Phrase.

Phrase contacted us regarding this change in their guest post. I took the chance and adapted it in all posts so that there won't be dead links later on if they do not support the PhraseApp links anymore.

"Hi Christina, wie Dir bestimmt schon mal aufgefallen ist, sind wir seit dem 1. August 2019 einfach Phrase. Wäre es möglich, die Links, die wir in unserem Gastartikel eingesetzt hatten, einfach auf phrase.com anzupassen? App sollte einfach aus allen Links entfernt werden. Dasselbe gilt für den Produktnamen, der am Ende des Artikels erwähnt ist."