### PR TITLE
Listen on all interfaces

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -353,5 +353,5 @@ task :write do
 
   File.open(write_file, 'w+') { |f| f.puts exclude.to_yaml }
 
-  sh 'bundle exec jekyll serve --config _config.yml,_config_write.yml'
+  sh 'bundle exec jekyll serve --config _config.yml,_config_write.yml --host 0.0.0.0'
 end


### PR DESCRIPTION
this is required for localhost:4000 to be reachable under Linux

(at least on my Ubuntu 19.10)

further reading: https://pythonspeed.com/articles/docker-connection-refused/