### PR TITLE
Update event page

### DIFF
--- a/_data/exhibitions.yml
+++ b/_data/exhibitions.yml
@@ -1,5 +1,5 @@
-- title: Currently no events are planned.
+- title: There are no events planned at the moment.
   link: 
   date: 
   time:
-  address: We keep you updated.
+  address: We will keep you updated.

--- a/_data/exhibitions.yml
+++ b/_data/exhibitions.yml
@@ -1,5 +1,5 @@
-- title: jobwalk Jena
-  link: https://jena.jobwalk.city/
-  date: 25. Sep 2021
+- title: Currently no events are planned.
+  link: 
+  date: 
   time:
-  address: Marktplatz Jena<br>Markt 1<br>07743 Jena
+  address: We keep you updated.

--- a/_data/exhibitions.yml
+++ b/_data/exhibitions.yml
@@ -1,5 +1,5 @@
 - title: There are no events planned at the moment.
-  link: 
-  date: 
+  link:
+  date:
   time:
   address: We will keep you updated.


### PR DESCRIPTION
As far as I know, there are no further events planned. That's why I would like to update the events page accordingly. This is what it looks like. In the long term, I would like to have a special design for this case, but until then I think this looks fine.

<img width="919" alt="Bildschirmfoto 2021-09-27 um 08 59 58" src="https://user-images.githubusercontent.com/79914794/134859635-e329659c-7b3b-4a89-8d3d-d68003babc44.png">
